### PR TITLE
fix: hide hapic feedback option incase of web

### DIFF
--- a/budget/lib/pages/debugPage.dart
+++ b/budget/lib/pages/debugPage.dart
@@ -195,19 +195,20 @@ class DebugPage extends StatelessWidget {
               ? Icons.battery_charging_full_outlined
               : Icons.battery_charging_full_rounded,
         ),
-        SettingsContainerSwitch(
-          enableBorderRadius: true,
-          onSwitched: (value) {
-            updateSettings("savingHapticFeedback", value,
-                pagesNeedingRefresh: [], updateGlobalState: false);
-          },
-          initialValue: appStateSettings["savingHapticFeedback"] == true,
-          title: "Saving Haptic Feedback".tr(),
-          description: "When saving changes or adding, provide haptic feedback",
-          icon: appStateSettings["outlinedIcons"]
-              ? Icons.vibration_outlined
-              : Icons.vibration_rounded,
-        ),
+        if (getPlatform(ignoreEmulation: true) != PlatformOS.web)
+          SettingsContainerSwitch(
+            enableBorderRadius: true,
+            onSwitched: (value) {
+              updateSettings("savingHapticFeedback", value,
+                  pagesNeedingRefresh: [], updateGlobalState: false);
+            },
+            initialValue: appStateSettings["savingHapticFeedback"] == true,
+            title: "Saving Haptic Feedback".tr(),
+            description: "When saving changes or adding, provide haptic feedback",
+            icon: appStateSettings["outlinedIcons"]
+                ? Icons.vibration_outlined
+                : Icons.vibration_rounded,
+          ),
         if (getPlatform(ignoreEmulation: true) == PlatformOS.isAndroid)
           SettingsContainerSwitch(
             onSwitched: (value) async {


### PR DESCRIPTION
In Cashew Web app, `Settings > More Options > Number Pad Format` gives us the option to set Haptic feedback where the option cannot be used.

I have made a simple change to hide this option when running on Web 