### PR TITLE
fix `ton` crypto name

### DIFF
--- a/budget/assets/static/currencies.json
+++ b/budget/assets/static/currencies.json
@@ -449,7 +449,7 @@
   "tmm": "Turkmenistani Manat",
   "tmt": "Turkmenistani Manat",
   "tnd": "Tunisian Dinar",
-  "ton": "Tokamak Network",
+  "ton": "TON",
   "tone": "TE-FOOD",
   "top": "Tongan Pa'anga",
   "trac": "OriginTrail",

--- a/budget/assets/static/generated/currencies.json
+++ b/budget/assets/static/generated/currencies.json
@@ -2435,7 +2435,7 @@
     "Symbol": "د.ت.‏"
   },
   "ton": {
-    "Currency": "Tokamak Network",
+    "Currency": "TON",
     "Code": "ton",
     "NotKnown": true
   },


### PR DESCRIPTION
cryptocurrency `TON` have a wrong name in application. you can check it by price from url:
https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/usd.min.json
exchange rate match to the [toncoin](https://coinmarketcap.com/en/currencies/toncoin/), not [tokamaka](https://coinmarketcap.com/currencies/tokamak-network/)