### PR TITLE
 fix(csv): Correctly parse CSV fields with newlines

### DIFF
--- a/budget/lib/widgets/importCSV.dart
+++ b/budget/lib/widgets/importCSV.dart
@@ -106,7 +106,6 @@ class _ImportCSVState extends State<ImportCSV> {
     try {
       List<List<String>> fileContents = CsvToListConverter().convert(
         csvString,
-        eol: '\n',
         shouldParseNumbers: false,
       );
       int maxColumns = fileContents.fold(

--- a/budget/test/csv_import_test.dart
+++ b/budget/test/csv_import_test.dart
@@ -1,0 +1,13 @@
+import 'package:csv/csv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('CSV with newline in field should be parsed correctly', () {
+    const csvString =
+        'Date,Amount,Category,Title,Note,Account\n11/11/2021 10:10:00,10,Dining,McD,"Burger\nChicken",Bank';
+    final List<List<dynamic>> result =
+        const CsvToListConverter().convert(csvString);
+    expect(result.length, 2);
+    expect(result[1][4], "Burger\nChicken");
+  });
+}


### PR DESCRIPTION
The CSV parser was configured to treat all newline characters as row terminators, causing an error when a field contained a newline. This change removes the explic end-of-line configuration, allowing the parser to correctly handle multiline fields within quotes.
 This fixes an issue where importing a CSV file with a newline in a field would fail with an "Unable to parse amount" error.
 
### Resolves ISSUE #972 
 