### PR TITLE
Minor typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,11 @@ Note: required Firebase.
 
 ### Wallets vs. Accounts
 
-- `Wallets` have been been renamed to `Accounts` on the front-end but internally, the name `Wallet` is still used.
+- `Wallets` have been renamed to `Accounts` on the front-end but internally, the name `Wallet` is still used.
 
 ### Objectives vs. Goals
 
-- `Objectives` have been been renamed to `Goals` on the front-end but internally, the name `Objectives` is still used.
+- `Objectives` have been renamed to `Goals` on the front-end but internally, the name `Objectives` is still used.
 
 ### Long Term Loans
 


### PR DESCRIPTION
I noticed a small typo in the README file. The word "been" was accidentally duplicated in two sentences about Wallets and Objectives renaming.

This is a minor documentation fix and my first pull request. I've just installed the app and seen it's open source. Thanks for the project!